### PR TITLE
Fix upwind finite difference for negative phi.

### DIFF
--- a/skfmm/distance_marcher.cpp
+++ b/skfmm/distance_marcher.cpp
@@ -14,7 +14,7 @@ double distanceMarcher::updatePointOrderOne(int i)
       naddr = _getN(i,dim,j,Mask);
       if (naddr!=-1 && flag_[naddr]==Frozen)
       {
-        if (distance_[naddr]<value)
+        if (fabs(distance_[naddr])<fabs(value))
         {
           value = distance_[naddr];
         }
@@ -50,7 +50,7 @@ double distanceMarcher::updatePointOrderTwo(int i)
       naddr = _getN(i,dim,j,Mask);
       if (naddr!=-1 && flag_[naddr]==Frozen)
       {
-        if (distance_[naddr]<value1)
+        if (fabs(distance_[naddr])<fabs(value1))
         {
           value1 = distance_[naddr];
           int naddr2 = _getN(i,dim,j*2,Mask);

--- a/skfmm/travel_time_marcher.cpp
+++ b/skfmm/travel_time_marcher.cpp
@@ -35,7 +35,7 @@ double travelTimeMarcher::updatePointOrderTwo(int i)
       naddr = _getN(i,dim,j,Mask);
       if (naddr!=-1 && flag_[naddr]==Frozen)
       {
-        if (distance_[naddr]<value1)
+        if (fabs(distance_[naddr])<fabs(value1))
         {
           value1 = distance_[naddr];
           int naddr2 = _getN(i,dim,j*2,Mask);


### PR DESCRIPTION
The upwind finite difference scheme is incorrect for negative phi. In each dimension we want to choose the frozen neighbour with the smaller *magnitude* of distance from the zero contour, not the neighbour with the smallest value (for which neighbours further inside the structure, with more negative phi, will win).

Owing to the nature of the algorithm, in which neighbours are updated outwards from the zero contour in a recursive fashion, this error only seems to cause issues for nodes lying close to the minimum of the level set, i.e. for regions in the middle of holes. The image below shows the position of nodes that are updated incorrectly (labeled as different) during level set optimisation of the classic 2:1 centrally loaded cantilever.

![diff](https://cloud.githubusercontent.com/assets/648557/10587113/9198a838-7697-11e5-9009-b58f703627e4.png)

Also note that, as implemented, the algorithm may give slightly different results to fast marching methods that update regions with positive and negative phi separately. In a two-pass scheme, it is possible to use the updated level set variables from the first pass in order to obtain a more accurate estimate for the position of frozen nodes adjacent to the zero contour in the second pass, i.e. in the linear interpolatation of distances from the boundary when there is a change in sign of phi between a node and its neigbour.