### PR TITLE
Return nearest contour point + memory leak fix

### DIFF
--- a/skfmm/base_marcher.cpp
+++ b/skfmm/base_marcher.cpp
@@ -8,8 +8,6 @@
 #include "math.h"
 #include <vector>
 
-#include <stdio.h>
-
 extern "C" {
 
 

--- a/skfmm/base_marcher.cpp
+++ b/skfmm/base_marcher.cpp
@@ -8,28 +8,29 @@
 #include "math.h"
 #include <vector>
 
+#include <stdio.h>
+
 extern "C" {
 
 
-baseMarcher::baseMarcher(
-  double *phi,      double *dx,   long *flag,
-  double *distance, int     ndim, int *shape,
-  bool self_test,   int order,    double narrow,
-  int periodic)
+baseMarcher::baseMarcher(double *phi,          double *dx,    long *flag,
+  double *distance,      int* nearest_contour, int    ndim,   int *shape,
+  bool self_test,        int order,            double narrow, int periodic)
 {
-  narrow_     =   narrow;
-  order_      =   order;
-  error_      =   1;
-  phi_        =   phi;
-  dx_         =   dx;
-  flag_       =   flag;
-  distance_   =   distance;
-  dim_        =   ndim;
-  size_       =   1;
-  self_test_  =   self_test;
-  heapptr_    =   0;
-  heap_       =   0;
-  periodic_   =   periodic;
+  narrow_          =   narrow;
+  order_           =   order;
+  error_           =   1;
+  phi_             =   phi;
+  dx_              =   dx;
+  flag_            =   flag;
+  distance_        =   distance;
+  nearest_contour_ = nearest_contour;
+  dim_             =   ndim;
+  size_            =   1;
+  self_test_       =   self_test;
+  heapptr_         =   0;
+  heap_            =   0;
+  periodic_        =   periodic;
 
   for (int i=0; i<dim_; i++)
   {
@@ -89,6 +90,7 @@ void baseMarcher::initalizeNarrow()
               d =  updatePointOrderOne(i);
 
             distance_[i] =  d;
+            nearest_contour_[i] = nearest_contour_[naddr];
             heapptr_[i]  =  heap_->push(i,fabs(d));
           }
         } // for each direction
@@ -186,6 +188,7 @@ void baseMarcher::solve()
               {
                 distance_[naddr]=d;
                 flag_[naddr]=Narrow;
+                nearest_contour_[naddr] = nearest_contour_[addr];
                 heapptr_[naddr] = heap_->push(naddr,fabs(d));
               }
             }

--- a/skfmm/base_marcher.h
+++ b/skfmm/base_marcher.h
@@ -18,10 +18,10 @@ extern "C" {
 class baseMarcher
 {
 public:
-  baseMarcher(double *phi,      double *dx,  long *flag,
-              double *distance, int ndim,    int *shape,
-              bool self_test,   int order,   double narrow,
-              int periodic);
+  baseMarcher(double *phi,      double *dx,           long *flag,
+              double *distance, int* nearest_contour, int ndim,
+              int *shape,       bool self_test,       int order,
+              double narrow,    int periodic);
 
   virtual          ~baseMarcher();
   void             march();
@@ -95,6 +95,7 @@ protected:
   double          * phi_;
   double          * dx_;
   long            * flag_;
+  int             * nearest_contour_;
   int               error_;
   int               dim_;            // number of dimensions
   int               size_;           // flat size

--- a/skfmm/distance_marcher.cpp
+++ b/skfmm/distance_marcher.cpp
@@ -115,6 +115,7 @@ void distanceMarcher::initalizeFrozen()
     {
       flag_[i]=Frozen;
       distance_[i]=0.0;
+      nearest_contour_[i] = i;
     }
   }
   //loop over all of phi and for each point check each direction

--- a/skfmm/distance_marcher.h
+++ b/skfmm/distance_marcher.h
@@ -6,10 +6,10 @@ class distanceMarcher : public baseMarcher
 {
 public:
   distanceMarcher(double *phi,      double *dx, long *flag,
-                  double *distance, int ndim,   int *shape,
+                  double *distance, int* nearest_mask, int ndim,   int *shape,
                   bool self_test,   int order,  double narrow,
                   int periodic):
-    baseMarcher(phi, dx, flag, distance, ndim, shape, self_test, order,
+    baseMarcher(phi, dx, flag, distance, nearest_mask, ndim, shape, self_test, order,
                 narrow, periodic) { }
   virtual ~distanceMarcher() { }
 

--- a/skfmm/extension_velocity_marcher.h
+++ b/skfmm/extension_velocity_marcher.h
@@ -6,11 +6,11 @@ class extensionVelocityMarcher : public distanceMarcher
 {
 public:
   extensionVelocityMarcher(double *phi,      double *dx,    long *flag,
-                           double *distance, int     ndim,  int *shape,
+                           double *distance, int* nearest_mask, int     ndim,  int *shape,
                            bool self_test,   int order,     long *ext_mask,
                            double *speed,
                            double *f_ext,    double narrow, int periodic) :
-    distanceMarcher(phi, dx, flag, distance, ndim, shape, self_test,
+    distanceMarcher(phi, dx, flag, distance, nearest_mask, ndim, shape, self_test,
                     order, narrow, periodic),
   speed_(speed), f_ext_(f_ext), ext_mask_(ext_mask) { }
   virtual ~extensionVelocityMarcher() { }

--- a/skfmm/travel_time_marcher.h
+++ b/skfmm/travel_time_marcher.h
@@ -6,11 +6,11 @@ class travelTimeMarcher : public distanceMarcher
 {
 public:
   travelTimeMarcher(double *phi,      double *dx, long *flag,
-                    double *distance, int ndim,   int *shape,
+                    double *distance, int* nearest_mask, int ndim,   int *shape,
                     bool self_test,   int order,
                     double *speed,    double narrow,
                     int periodic) :
-    distanceMarcher(phi, dx, flag, distance, ndim, shape, self_test,
+    distanceMarcher(phi, dx, flag, distance, nearest_mask, ndim, shape, self_test,
                     order, narrow, periodic),
     speed_(speed)
   {


### PR DESCRIPTION
This is related to issue #29 . Two key changes have been made:

1) A new `return_nearest_contour` option has been added to the `distance`, `travel_time` and `extension_velocities` functions (default to False). If true, the function returns an additional array which contains the coordinates of the nearest phi = 0 point for each point in the input array. For e.g., for a 2D image of size HxW, the returned nearest contour array will have size HxWx2.

2) The current code can leak memory because of the way in which `Py_BuildValue` is used. Specifically, using `O` in the format string causes the reference counter of the objects to be increased, so the returned array(s) are never freed. The solution is to use `N` instead, which doesn't increase the reference counter.

I didn't name the option 'image_gradient' since it returns the absolute coordinates of the nearest phi = 0 point, not the coordinate offset to it, but that can be changed easily.

I also wrote a simple interactive script that can be used to test the functionality. The code for it is pasted here (requires OpenCV, NumPy). It basically converts the generated distance array into an easily visualizable color map. Clicking anywhere on the image causes the nearest contour point to be marked with a green circle (the exact coordinates are also printed to console).

https://www.pastiebin.com/5d1a070f101a2

A simple test image on which it can be applied (change the file path in the script accordingly). It appears all black but there are some points with intensity 1:

![mask](https://user-images.githubusercontent.com/14821941/60439235-c2059180-9c12-11e9-8538-4138602e74b7.png)

