### PR TITLE
Hotfix for second order update in travel time

### DIFF
--- a/skfmm/distance_marcher.cpp
+++ b/skfmm/distance_marcher.cpp
@@ -27,8 +27,7 @@ double distanceMarcher::updatePointOrderOne(int i)
       c+=idx2_[dim]*pow(value,2);
     }
   }
-  bool pass;
-  double tmp = solveQuadratic(i, a, b, c, &pass);
+  double tmp = solveQuadratic(i,a,b,c);
   return tmp;
 }
 
@@ -79,8 +78,7 @@ double distanceMarcher::updatePointOrderTwo(int i)
       c+=idx2_[dim]*pow(value1,2);
     }
   }
-  bool pass;
-  double tmp = solveQuadratic(i, a, b, c, &pass);
+  double tmp = solveQuadratic(i,a,b,c);
   return tmp;
 }
 
@@ -88,7 +86,7 @@ double distanceMarcher::updatePointOrderTwo(int i)
 // find and return the correct root
 double distanceMarcher::solveQuadratic(int i, const double &a,
                                        const double &b,
-                                       double &c, bool *pass)
+                                       double &c)
 {
   c-=1;
   double r0=0;

--- a/skfmm/distance_marcher.h
+++ b/skfmm/distance_marcher.h
@@ -15,7 +15,7 @@ public:
 
 protected:
   virtual double           solveQuadratic(int i, const double &a,
-                                          const double &b, double &c, bool *pass);
+                                          const double &b, double &c);
 
   virtual void             initalizeFrozen();
   virtual double           updatePointOrderOne(int i);

--- a/skfmm/travel_time_marcher.cpp
+++ b/skfmm/travel_time_marcher.cpp
@@ -4,6 +4,8 @@
 #include "math.h"
 #include "heap.h"
 #include <stdexcept>
+#include <vector>
+#include <algorithm>    // std::min_element, std::max_element
 
 void travelTimeMarcher::initalizeFrozen()
 {
@@ -18,28 +20,35 @@ void travelTimeMarcher::initalizeFrozen()
   }
 }
 
+double travelTimeMarcher::updatePointOrderTwo(int i)
+{
+    double res = updatePointOrderTwo(i, std::set<int>());
+    if(res == std::numeric_limits<double>::infinity())
+        throw std::runtime_error("Unreachable voxel");
+    else
+        return res;
+}
+
+
 // second order point update
 // update the distance from the frozen points
 const double aa         =  9.0/4.0;
 const double oneThird   =  1.0/3.0;
-double travelTimeMarcher::updatePointOrderTwo(int i)
+double travelTimeMarcher::updatePointOrderTwo(int i, std::set<int>avoid_dim)
 {
   double a,b,c;
   a=b=c=0;
   int naddr=0;
-  double closest_neighbor = maxDouble;
-  for (int dim=0; dim<dim_; dim++)  // each dimension
+  for (int dim=0; dim<dim_; dim++)
   {
+    if(avoid_dim.find(dim) != avoid_dim.end()) continue; //we should avoid this dimension
     double value1 = maxDouble;
     double value2 = maxDouble;
-    for (int j=-1; j<2; j+=2)  // each direction (positive or negative)
+    for (int j=-1; j<2; j+=2) // each direction
     {
       naddr = _getN(i,dim,j,Mask);
       if (naddr!=-1 && flag_[naddr]==Frozen)
       {
-        if (distance_[naddr]<closest_neighbor) {
-          closest_neighbor = distance_[naddr];
-        }
         if (fabs(distance_[naddr])<fabs(value1))
         {
           value1 = distance_[naddr];
@@ -70,32 +79,40 @@ double travelTimeMarcher::updatePointOrderTwo(int i)
       c+=idx2_[dim]*pow(value1,2);
     }
   }
-  bool pass;
-  double trial_value = solveQuadratic(i,a,b,c,&pass);
-  if (pass) {
-    return trial_value;
-  } else {
-    return 1/speed_[i] + closest_neighbor;
+  try{
+    double res = solveQuadratic(i,a,b,c);
+    return res;
+  }catch(std::runtime_error& err){
+    //if the determinant is negative, we try to reach the voxel with one dimension less and take the minimum
+    if(avoid_dim.size() == dim_) return std::numeric_limits<double>::infinity(); //end of the recursion, use inf so that it is discarded selecting the minimum
+    std::vector<double> sols;
+    for (int ind=0; ind<dim_; ind++){
+        //remove one dimension more than what we are already doing
+        std::set<int> tempset = avoid_dim;
+        auto ret = tempset.insert(ind);
+        if(!ret.second) continue; //avoid recursive call on identical parameters (the set already had *ind* in it)
+        sols.push_back(updatePointOrderTwo(i,tempset));
+    }
+    if(sols.size()==0) return std::numeric_limits<double>::infinity();//All the derivates with different dimensionalities are 0
+    return *std::min_element(sols.begin(), sols.end());
   }
 }
 
 
 double travelTimeMarcher::solveQuadratic(int i, const double &a,
                                          const double &b,
-                                         double &c, bool *pass)
+                                         double &c)
 {
-  c -= 1/pow(speed_[i], 2);
+  c -= 1/pow(speed_[i],2);
   double r0=0;
-  double det = pow(b, 2) - 4*a*c;
+  double det = pow(b,2)-4*a*c;
   if (det>=0)
   {
-    r0 = (-b + sqrt(det))/2.0/a;
+    r0 = (-b+sqrt(det))/2.0/a;
   }
   else
   {
-    *pass = false;
-    return 0;
+    throw std::runtime_error("Negative discriminant in time marcher quadratic.");
   }
-  *pass = true;
   return r0;
 }

--- a/skfmm/travel_time_marcher.h
+++ b/skfmm/travel_time_marcher.h
@@ -1,5 +1,7 @@
 //travel_time_marcher.h
 #include "distance_marcher.h"
+#include <set>
+
 class heap;
 
 class travelTimeMarcher : public distanceMarcher
@@ -27,8 +29,9 @@ public:
 protected:
   virtual void             initalizeFrozen();
   virtual double           updatePointOrderTwo(int i);
+  virtual double           updatePointOrderTwo(int i, std::set<int> avoid_dim);
   virtual double           solveQuadratic(int i, const double &a,
-                                          const double &b, double &c, bool *pass);
+                                          const double &b, double &c);
 private:
   double *speed_;
 };


### PR DESCRIPTION
According to many sources, starting from wikipedia [Eikonal equation](https://en.wikipedia.org/wiki/Eikonal_equation#n-D_approximation_on_a_Cartesian_grid) to some research papers and PhD thesis, in case the discriminant is less than 0 one should try the updates with one dimension less and select the minimum. This is not happening on master branch, and in travel-time-fix only the 1D dimension is used as fallback.
The code with this pull request does the dimensionality decrease in the generic n-D case, falling back to (n-1)-D, and so on.
This commit is only partial and has two main issues. 
1. It only fix the second order update, but it should apply equally to the first order update (I just could not find the code for it in the files).
2. The code is potentially inefficient as the recursion can potentially try to solve all the (n)-D, (n-1)-D, ..., (1-D) dimensional updates; From my understanding, the (n-k-1)-D should be checked only if ALL (n-k)-D updates have discriminant < 0. This is not a big problem in 3D, but it could be quite slow with high dimensionality inputs.

From my tests this fixes the issues #28 and #18 .