### PR TITLE
Replaced "np.int" by "int" to remove the deprecation warning of Numpy.

### DIFF
--- a/skfmm/pfmm.py
+++ b/skfmm/pfmm.py
@@ -16,28 +16,28 @@ def pre_process_args(phi, dx, narrow, periodic, ext_mask=None):
         phi = np.array(phi)
 
     if type(dx) is float or type(dx) is int:
-        dx = [dx for x in range(phi.ndim)]
+        dx = [dx for _ in range(phi.ndim)]
     dx = np.array(dx)
 
     if isinstance(phi, np.ma.MaskedArray):
-        flag = np.zeros(phi.shape, dtype=np.int)
+        flag = np.zeros(phi.shape, dtype=int)
         flag[phi.mask] = MASK
         phi = phi.data
     else:
-        flag = np.zeros(phi.shape, dtype=np.int)
+        flag = np.zeros(phi.shape, dtype=int)
 
     if ext_mask is None:
-        ext_mask = np.zeros(phi.shape, dtype=np.int)
+        ext_mask = np.zeros(phi.shape, dtype=int)
 
     periodic_data = 0
     if isinstance(periodic, bool):
         if periodic:
-            periodic_data = int(2**phi.ndim-1)
+            periodic_data = int(2 ** phi.ndim - 1)
     else:
         if hasattr(periodic, "__len__") and len(periodic) == phi.ndim:
             for i, value in enumerate(periodic):
                 if value:
-                    periodic_data |= 1<<i
+                    periodic_data |= 1 << i
         else:
             raise ValueError("parameter \"periodic\" must be of type bool or sequence of type bool of length phi.ndim.")
 
@@ -106,7 +106,7 @@ def distance(phi, dx=1.0, self_test=False, order=2,
 
     """
     phi, dx, flag, ext_mask, periodic = \
-                        pre_process_args(phi, dx, narrow, periodic)
+        pre_process_args(phi, dx, narrow, periodic)
     d = cFastMarcher(phi, dx, flag, None, ext_mask,
                      int(self_test), DISTANCE, order, narrow, periodic)
     d = post_process_result(d)
@@ -234,7 +234,7 @@ def extension_velocities(phi, speed, dx=1.0, self_test=False, order=2,
 
     """
     phi, dx, flag, ext_mask, periodic = \
-                pre_process_args(phi, dx, narrow, periodic, ext_mask)
+        pre_process_args(phi, dx, narrow, periodic, ext_mask)
 
     distance, f_ext = cFastMarcher(phi, dx, flag, speed, ext_mask,
                                    int(self_test), EXTENSION_VELOCITY,


### PR DESCRIPTION
I replaced "np.int" by "int" in pfmm.py to remove the deprecation warning of Numpy, and did some very light reformatting.

Warning in question:
DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    flag = np.zeros(phi.shape, dtype=np.int)