### PR TITLE
If solveQuadratic fails for second order switch to first order

### DIFF
--- a/skfmm/distance_marcher.cpp
+++ b/skfmm/distance_marcher.cpp
@@ -1,5 +1,6 @@
 #include "distance_marcher.h"
 #include "math.h"
+#include <stdexcept>
 
 double distanceMarcher::updatePointOrderOne(int i)
 {
@@ -27,8 +28,13 @@ double distanceMarcher::updatePointOrderOne(int i)
       c+=idx2_[dim]*pow(value,2);
     }
   }
-  double tmp = solveQuadratic(i,a,b,c);
-  return tmp;
+  try {
+    return solveQuadratic(i,a,b,c);
+  } catch(std::runtime_error& err) {
+    // if the quadratic equation can't be solved, use the
+    // position of the minimum as a more reasonable approximation
+    return -b / (2.0 * a);
+  }
 }
 
 
@@ -78,8 +84,12 @@ double distanceMarcher::updatePointOrderTwo(int i)
       c+=idx2_[dim]*pow(value1,2);
     }
   }
-  double tmp = solveQuadratic(i,a,b,c);
-  return tmp;
+  try {
+    return solveQuadratic(i,a,b,c);
+  } catch(std::runtime_error& err) {
+    // if the second order method fails, try the first order method instead
+    return updatePointOrderOne(i);
+  }
 }
 
 
@@ -90,14 +100,14 @@ double distanceMarcher::solveQuadratic(int i, const double &a,
 {
   c-=1;
   double det = pow(b,2)-4*a*c;
-  if (det > 0)
+  if (det >= 0)
   {
     if (phi_[i] > doubleEpsilon) { return (-b + sqrt(det)) / 2.0 / a; }
     else                         { return (-b - sqrt(det)) / 2.0 / a; }
   }
   else
   {
-    return 0;
+    throw std::runtime_error("Negative discriminant in time marcher quadratic.");
   }
 }
 

--- a/skfmm/distance_marcher.cpp
+++ b/skfmm/distance_marcher.cpp
@@ -107,7 +107,7 @@ double distanceMarcher::solveQuadratic(int i, const double &a,
   }
   else
   {
-    throw std::runtime_error("Negative discriminant in time marcher quadratic.");
+    throw std::runtime_error("Negative discriminant in distance marcher quadratic.");
   }
 }
 


### PR DESCRIPTION
I've run into an issue where the discriminant in solveQuadratic for the distance_marcher turned negative, causing  solveQuadratic to return zero.
A short example where such an issue arises would be for the following code:
```
import numpy as np
import skfmm 
a = np.array(
[[[600,  399,  641],
  [607,  605,  796],
  [602,  641,  797],
  [602,  658,  814]],
 [[272,   -1,  398],
  [208,  282,  539],
  [209,  285,  513],
  [208,  298,  519]],
 [[-19,   51,  307],
  [-191,   2,  403],
  [-171,   5,  325],
  [-172,   3,  318]]])
d = skfmm.distance(a)
print(d)
```

Looking at the values for the calculation of `updatePointOrderTwo(19)`, the difference between the extrapolated value `tp` and a neighboring point on another axis became greater than their euclidean distance.

The fix I implemented for this was that instead of returning zero, an exception is thrown similar to travel_time_marcher.cpp.
If this exception is caught for `updatePointOrderTwo` it will instead try using `updatePointOrderOne`.
In the example above, such an issue does not arise for the first order.
However, should such an issue arise in `updatePointOrderOne`, I would suggest returning the position of the minimum of the quadratic equation as this would be a more reasonable value for the distance instead of returning zero, especially if the discriminant falls only slightly below zero due to numerical inaccuracies.

Additionally, I replaced the `det > 0` with `det >= 0` as a discriminant of exactly zero should be perfectly fine.