### PR TITLE
Build against the oldest supported Numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 requires = [
     "wheel",
     "setuptools",
-    "numpy >= 1.0.2",
+    "oldest-supported-numpy",
 ]


### PR DESCRIPTION
`oldest-supported-numpy` provides the oldest supported version of Numpy for each Python version.

Since binaries compiled with old Numpy versions are compatible with binaries compiled with newer Numpy versions (but not vice versa), this fixes #58.

See https://pypi.org/project/oldest-supported-numpy/ for more details.