### PR TITLE
add py_modules to support setuptools behavior changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ def setup_package():
         url              = URL,
         license          = LICENSE,
         keywords         = KEYWORDS,
+        py_modules       = [],
         long_description = long_description,
         configuration    = configuration,
         install_requires = ['numpy >= 1.0.2'],


### PR DESCRIPTION
Following the Breaking Changes in setuptools v61.0.0 it is suggested to set py_modules to disable auto-discovery behavior.