### PR TITLE
Pin setuptools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools==64.0.0",
     "oldest-supported-numpy",
 ]


### PR DESCRIPTION
Setuptools 65.0.0 introduced some breaking changes, which break the scikit-fmm installation. 
Pinning to 64.0.0 will solve this problem.