### PR TITLE
releasing GIL while marching

### DIFF
--- a/skfmm/fmm.cpp
+++ b/skfmm/fmm.cpp
@@ -305,7 +305,9 @@ static PyObject *distance_method(PyObject *self, PyObject *args)
   }
 
   try {
+      Py_BEGIN_ALLOW_THREADS
       marcher->march();
+      Py_END_ALLOW_THREADS
       error = marcher->getError();
       delete marcher;
     } catch (const std::exception& exn) {


### PR DESCRIPTION
Wrap `marcher->march()` to release the GIL.

This allows effective parallisation of expensive marching.