### PR TITLE
Add Windows ARM wheels. Update workflows.

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,10 +1,18 @@
 name: Build and publish wheels
 
 on:
-  push:
-    tags:
-      - '*'  # Triggers the workflow on version tags
-
+  workflow_dispatch:
+    inputs:
+      upload:
+        description: 'Upload wheels and sdist to PyPI? (0: no, 1: yes)'
+        required: true
+        default: '0'
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  
 permissions:
   contents: write
   actions: read
@@ -36,6 +44,10 @@ jobs:
         include:
           - os: windows-latest
             arch: auto64
+            msvc_arch: x64  
+          - os: windows-11-arm
+            arch: ARM64
+            msvc_arch: ARM64        
           - os: ubuntu-22.04
             arch: x86_64
           - os: ubuntu-22.04-arm
@@ -51,18 +63,21 @@ jobs:
 
       - uses: actions/setup-python@v5
       
+      - name: Activate MSVC
+        uses: ilammy/msvc-dev-cmd@v1.13.0
+        with:
+          arch: ${{ matrix.msvc_arch }}
+        if: ${{ matrix.msvc_arch }}
+      
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22
+        uses: pypa/cibuildwheel@v2.23.3
         env:
-          CIBW_SKIP: "*pp3* *cp38*"
+          CIBW_SKIP: ${{ runner.os == 'Windows' && runner.arch == 'ARM64' && '*pp3* *cp38* *cp39* *cp310*' || '*pp3* *cp38*' }}
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--vsenv"
           CIBW_ENVIRONMENT_MACOS:
             MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos_deployment_target }}
           CIBW_TEST_REQUIRES: numpy
           CIBW_TEST_COMMAND: |
-           python -c "import skfmm, sys; sys.exit(skfmm.test())"
-           pip install numpy==1.26.4
            python -c "import skfmm, sys; sys.exit(skfmm.test())"
           
       - name: Upload artifacts
@@ -88,32 +103,12 @@ jobs:
       
       - uses: actions/download-artifact@v4
         with:
-          name: wheels-ubuntu-22.04-x86_64
+          pattern: wheels-*
+          merge-multiple: true
           path: dist
-      
-      - uses: actions/download-artifact@v4
-        with:
-          name: wheels-ubuntu-22.04-arm-aarch64
-          path: dist
-      
-      - uses: actions/download-artifact@v4
-        with:
-          name: wheels-macos-13-x86_64
-          path: dist
-      
-      - uses: actions/download-artifact@v4
-        with:
-          name: wheels-macos-14-arm64
-          path: dist
-      
-      - uses: actions/download-artifact@v4
-        with:
-          name: wheels-windows-latest-auto64
-          path: dist
-
+          
       - name: Upload wheels and sdist to PyPI
-        # release on every tag
-        if: ${{ github.ref_type == 'tag' }}
+        if: ${{ github.event.inputs.upload == '1'}}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/windows_arm_build.yaml
+++ b/.github/workflows/windows_arm_build.yaml
@@ -1,20 +1,19 @@
-name: Linux Build
+name: Windows ARM Build
 
-on:
+on: 
   workflow_dispatch:
   pull_request:
     types:
       - opened
       - synchronize
       - reopened
-
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-11-arm
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11","3.12","3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -22,22 +21,26 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: ilammy/msvc-dev-cmd@v1.13.0
+        with:
+          arch: ARM64
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install numpy wheel build
+          pip install numpy wheel
       - name: Build extension
         run: |
           python --version
           python -c "import struct; print(struct.calcsize('P') * 8)"
+          pip install build
           python -m build
           pip install .
           pip list
-          cd .. && python -c "import skfmm; print(skfmm.__version__)"
-      - name: Run skfmm tests
-        run: |
-          cd .. && python -c "import skfmm, sys; sys.exit(skfmm.test())"
       - uses: actions/upload-artifact@v4
         with:
-          name: linux-cp-${{ matrix.python-version }}-wheel
+          name: windows-arm-cp-${{ matrix.python-version }}-wheel
           path: dist/*
+      - name: Run skfmm tests
+        run: |
+          python -c 'import os; os.chdir(".."); import skfmm; print(skfmm.__version__)'
+          python -c 'import os; os.chdir(".."); import skfmm, sys; sys.exit(skfmm.test())'

--- a/.github/workflows/windows_build.yaml
+++ b/.github/workflows/windows_build.yaml
@@ -1,22 +1,27 @@
-name: Windows Build
+name: Windows x64 Build
 
-on: [push]
-
+on: 
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 jobs:
   build:
 
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9","3.10","3.11","3.12","3.13"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@v1.13.0
         with:
           arch: x64
       - name: Install dependencies
@@ -31,9 +36,9 @@ jobs:
           python -m build
           pip install .
           pip list
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: windows-artifacts
+          name: windows-x64-cp-${{ matrix.python-version }}-wheel
           path: dist/*
       - name: Run skfmm tests
         run: |


### PR DESCRIPTION
- Add Windows ARM wheels
- Enable MSVC with Ilammy@1.13.0
- Implement manual workflow dispatch (available from the master branch)
- Streamline artifact download (from the Shapely workflow)
- Optionally enable the upload of wheels to PyPI
- Utilize pypa/cibuildwheel@v2.23.3
