### PR TITLE
fix: correct initalizeFrozen -> initializeFrozen method name typo

### DIFF
--- a/skfmm/base_marcher.cpp
+++ b/skfmm/base_marcher.cpp
@@ -45,7 +45,7 @@ baseMarcher::baseMarcher(
 
 void baseMarcher::march()
 {
-  initalizeFrozen();
+  initializeFrozen();
 
   int maxHeap=0;
   for (int i=0; i<size_; i++)

--- a/skfmm/base_marcher.h
+++ b/skfmm/base_marcher.h
@@ -59,7 +59,7 @@ private:
 
 protected:
   // derived classes must implement these functions
-  virtual void     initalizeFrozen() = 0;
+  virtual void     initializeFrozen() = 0;
   virtual double   updatePointOrderTwo(int i) = 0;
   virtual double   updatePointOrderOne(int i) = 0;
 

--- a/skfmm/distance_marcher.cpp
+++ b/skfmm/distance_marcher.cpp
@@ -112,7 +112,7 @@ double distanceMarcher::solveQuadratic(int i, const double &a,
 }
 
 
-void distanceMarcher::initalizeFrozen()
+void distanceMarcher::initializeFrozen()
 {
   //loop over phi to find zero values
   //  and mark them as frozen

--- a/skfmm/distance_marcher.h
+++ b/skfmm/distance_marcher.h
@@ -17,7 +17,7 @@ protected:
   virtual double           solveQuadratic(int i, const double &a,
                                           const double &b, double &c);
 
-  virtual void             initalizeFrozen();
+  virtual void             initializeFrozen();
   virtual double           updatePointOrderOne(int i);
   virtual double           updatePointOrderTwo(int i);
 };

--- a/skfmm/extension_velocity_marcher.cpp
+++ b/skfmm/extension_velocity_marcher.cpp
@@ -7,7 +7,7 @@
 
 #include "math.h"
 
-void extensionVelocityMarcher::initalizeFrozen()
+void extensionVelocityMarcher::initializeFrozen()
 {
   //loop over phi to find zero values
   //  and mark them as frozen

--- a/skfmm/extension_velocity_marcher.h
+++ b/skfmm/extension_velocity_marcher.h
@@ -16,7 +16,7 @@ public:
   virtual ~extensionVelocityMarcher() { }
 
 protected:
-  virtual void             initalizeFrozen();
+  virtual void             initializeFrozen();
   virtual void             finalizePoint(int i, double phi_i);
   virtual void             cleanUp();
 

--- a/skfmm/travel_time_marcher.cpp
+++ b/skfmm/travel_time_marcher.cpp
@@ -7,9 +7,9 @@
 #include <vector>
 #include <algorithm>    // std::min_element, std::max_element
 
-void travelTimeMarcher::initalizeFrozen()
+void travelTimeMarcher::initializeFrozen()
 {
-  distanceMarcher::initalizeFrozen();
+  distanceMarcher::initializeFrozen();
   for (int i=0; i<size_; i++)
   {
     if (flag_[i]==Frozen)

--- a/skfmm/travel_time_marcher.h
+++ b/skfmm/travel_time_marcher.h
@@ -27,7 +27,7 @@ public:
   virtual ~travelTimeMarcher() { }
 
 protected:
-  virtual void             initalizeFrozen();
+  virtual void             initializeFrozen();
   virtual double           updatePointOrderTwo(int i);
   virtual double           updatePointOrderTwo(int i, std::set<int> avoid_dim);
   virtual double           solveQuadratic(int i, const double &a,


### PR DESCRIPTION
Correct misspelled method name `initalizeFrozen` -> `initializeFrozen` across all declarations and definitions (8 files).

Files changed:
- distance_marcher.h/cpp
- travel_time_marcher.h/cpp  
- base_marcher.h/cpp
- extension_velocity_marcher.h/cpp

Issue: scikit-fmm/scikit-fmm#107